### PR TITLE
Fix exception when reindexing deleted files.

### DIFF
--- a/rbb_tools/src/rbb_tools/commands/index.py
+++ b/rbb_tools/src/rbb_tools/commands/index.py
@@ -38,6 +38,7 @@ def register_bag_file(api, store_name, file):
     bag.topics=[]
     bag.products=[]
     bag.extraction_failure = False
+    bag.in_trash = False
 
     api.put_bag_meta(store_name, bag.name, bag)
 


### PR DESCRIPTION
This fixes #1 by setting in_trash=false (instead of None/null), when the the file is indexed.